### PR TITLE
Add support for client IP address blocking and a blocking cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ token: ''
 respect_do_not_track: true
 enable_cookies: false
 enable_javascript: false
+# Array of blocked client IP addresses for which tracking will be disabled.
+blockedIpAddresses: []
+# Array of blocked client IPv4 and/or IPv6 address ranges in the form
+# ["192.177.204.1-192.177.204.254", "2001:db8::1-2001:db8::fe", ...].
+# In addition to numerical ranges, the keywords "private", "loopback", "link-local" are recognized,
+# designating special IPv4 and IPv6 ranges (see RFCs 6890, 4193, 4291).
+blockedIpRanges: ["private", "loopback", "link-local"]
+# Name of a blocking cookie, which disables Matomo JS and PHP tracking, when set.
+blockingCookie: "blockMatomo"
 
 # Grav admin plugin dashboard settings
 # The dashboard token must only have read access:

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ dashboard_token: ''
 # This is useful if you have a test and production environment
 # and always want to show the production stats in the admin panel.
 dashboard_site_id: ''
+
+# Development settings
+# Enable this to add debug output about blocking reasons to the page's HTML source ('Matomo tracking blocked').
+debug: false
 ```
 
 Note that if you use the Admin Plugin, a file with your configuration named matomo.yaml will be saved in the `user/config/plugins/`-folder once the configuration is saved in the Admin.

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -101,6 +101,29 @@ form:
           validate:
             type: bool
 
+        blockedIpAddresses:
+          type: array
+          size: large
+          label: PLUGIN_MATOMO.BLOCKED_IP_ADDRESSES
+          help: PLUGIN_MATOMO.BLOCKED_IP_ADDRESSES_HELP
+          placeholder_value: PLUGIN_MATOMO.BLOCKED_IP_ADDRESSES_VALUE
+          value_only: true
+
+        blockedIpRanges:
+          type: array
+          size: large
+          label: PLUGIN_MATOMO.BLOCKED_IP_RANGES
+          help: PLUGIN_MATOMO.BLOCKED_IP_RANGES_HELP
+          placeholder_value: PLUGIN_MATOMO.BLOCKED_IP_RANGES_VALUE
+          value_only: true
+
+        blockingCookie:
+          type: text
+          label: PLUGIN_MATOMO.BLOCKING_COOKIE
+          help: PLUGIN_MATOMO.BLOCKING_COOKIE_HELP
+          size: small
+          default: "blockMatomo"
+
     dashboard:
       type: section
       title: PLUGIN_MATOMO.DASHBOARD

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -141,3 +141,20 @@ form:
           help: PLUGIN_MATOMO.DASHBOARD_SITE_ID_HELP
           validate:
             min: 1
+
+    development:
+      type: section
+      title: PLUGIN_MATOMO.DEVELOPMENT
+
+      fields:
+        debug:
+          type: toggle
+          label: PLUGIN_MATOMO.ENABLE_DEBUG
+          help: PLUGIN_MATOMO.ENABLE_DEBUG_HELP
+          highlight: 1
+          default: 0
+          options:
+            1: PLUGIN_ADMIN.ENABLED
+            0: PLUGIN_ADMIN.DISABLED
+          validate:
+            type: bool

--- a/languages.yaml
+++ b/languages.yaml
@@ -1,6 +1,5 @@
 en:
   PLUGIN_MATOMO:
-    INVALID_CONFIG: 'Invalid Matomo configuration detected'
     CONNECTION: 'Connection'
     MATOMO_URL: 'Matomo URL'
     MATOMO_URL_HELP: 'The URL of your matomo installation'
@@ -29,3 +28,6 @@ en:
     DASHBOARD_SITE_ID_HELP: 'Optional Side Id to show in Dashboard. Defaults to the tracked site id.'
     DASHBOARD_TOKEN: 'Dashboard Token'
     DASHBOARD_TOKEN_HELP: 'To use the dashboard you must add a new user with only read access: https://matomo.org/docs/embed-matomo-reports/#embed-piwik-widgets-on-a-password-protected-or-private-page'
+    DEVELOPMENT: 'Development'
+    ENABLE_DEBUG: 'Enable Debug Output'
+    ENABLE_DEBUG_HELP: "Enable this to add debug output about blocking reasons to the page's HTML source."

--- a/languages.yaml
+++ b/languages.yaml
@@ -12,9 +12,17 @@ en:
     RESPECT_DO_NOT_TRACK: 'Respect "Do Not Track" browser setting'
     RESPECT_DO_NOT_TRACK_HELP: 'If the browser sends a "Do Not Track" header, the visit will not be counted.'
     ENABLE_COOKIES: 'Enable Cookies'
-    ENABLE_COOKIES_HELP: 'Can be used to set cookies for better user tracking. Note that this may require an idditional cookie banner to be GDPR/DSGVO compliant.'
+    ENABLE_COOKIES_HELP: 'Can be used to set cookies for better user tracking. Note that this may require an additional cookie banner to be GDPR/DSGVO compliant.'
     ENABLE_JAVASCRIPT: 'Enable Javascript'
     ENABLE_JAVASCRIPT_HELP: 'Enable client side tracking via javascript rather than the server side php tracker.'
+    BLOCKED_IP_ADDRESSES: "Blocked Client IP Addresses"
+    BLOCKED_IP_ADDRESSES_HELP: "Disables Matomo tracking for clients on the given IP addresses."
+    BLOCKED_IP_ADDRESSES_VALUE: "IP address"
+    BLOCKED_IP_RANGES: "Blocked Client IP Address Ranges"
+    BLOCKED_IP_RANGES_HELP: "Disables Matomo tracking for clients on the given IPv4 or IPv6 address ranges."
+    BLOCKED_IP_RANGES_VALUE: "IP range (e.g. '10.4.3.1-10.4.3.20'), or 'private', 'loopback', or 'link-local'"
+    BLOCKING_COOKIE: "Blocking Cookie"
+    BLOCKING_COOKIE_HELP: "Name of a blocking cookie, which disables Matomo tracking, when set."
     DASHBOARD_HEADLINE: 'Matomo Dashboard'
     DASHBOARD: 'Dashboard'
     DASHBOARD_SITE_ID: 'Dashboard Site Id'

--- a/matomo.yaml
+++ b/matomo.yaml
@@ -12,6 +12,15 @@ token: ''
 respect_do_not_track: true
 enable_cookies: false
 enable_javascript: false
+# Array of blocked client IP addresses for which tracking will be disabled.
+blockedIpAddresses: []
+# Array of blocked client IPv4 and/or IPv6 address ranges in the form
+# ["192.177.204.1-192.177.204.254", "2001:db8::1-2001:db8::fe", ...].
+# In addition to numerical ranges, the keywords "private", "loopback", "link-local" are recognized,
+# designating special IPv4 and IPv6 ranges (see RFCs 6890, 4193, 4291).
+blockedIpRanges: ["private", "loopback", "link-local"]
+# Name of a blocking cookie, which disables Matomo JS and PHP tracking, when set.
+blockingCookie: "blockMatomo"
 
 # Grav admin plugin dashboard settings
 # The dashboard token must only have read access:

--- a/matomo.yaml
+++ b/matomo.yaml
@@ -30,3 +30,7 @@ dashboard_token: ''
 # This is useful if you have a test and production environment
 # and always want to show the production stats in the admin panel.
 dashboard_site_id: ''
+
+# Development settings
+# Enable this to add debug output about blocking reasons to the page's HTML source ('Matomo tracking blocked').
+debug: false


### PR DESCRIPTION
This pull request adds the following capabilities:
* Block Matomo tracking for configurable client IP addresses and/or IPv4/IPv6 address ranges.
* Block Matomo tracking via a blocking cookie.

These features already exist in the [Google Analytics plugin for Grav](https://github.com/escopecz/grav-ganalytics#grav-google-analytics-plugin) (introduced via [my pull request there](https://github.com/escopecz/grav-ganalytics/pull/11)) and have been in production use for quite some time.

#### Rationale

##### Why block client IP address ranges?

If your Matomo plugin is configured to send tracking events to a production Matomo server on the Internet, it will also send tracking events there when you use it with a Grav testing server on your local network. This is usually undesirable.

The following (default) setting disables tracking when a client connects to the server via local networks, while leaving it on for production installations:
```yaml
blockedIpRanges: ["private", "loopback", "link-local"]
```

You may also specify your testing client address or your testing client's IPv4 or IPv6 address range in `blockedIpAddresses` or `blockedIpRanges` respectively.

##### Why use an additional blocking cookie?

Two reasons:

1. To allow users to opt out from PHP tracking. Unfortunately, [Matomo's opt-out cookie](https://matomo.org/faq/general/faq_20000/) works for JavaScript tracking only. It does not disable PHP tracking.

1. To test a production site without changing its configuration. The cookie can be used to exclude test clients from tracking, while leaving it enabled for everyone else.

##### How to set a blocking cookie?

Use this PHP script as is or adapt it to your needs: [setGravMatomoTrackingPreferences.php](https://gist.github.com/OliverO2/a708c3cf9a7c723d3da1c7c56f7ae8ef#file-setgravmatomotrackingpreferences-php)